### PR TITLE
Adaptation to Python3.12.

### DIFF
--- a/import_ipynb.py
+++ b/import_ipynb.py
@@ -1,7 +1,11 @@
-import io, os, sys, types
-from IPython import get_ipython
+import io
+import os
+import sys
+import importlib
+from importlib.machinery import ModuleSpec
 from nbformat import read
 from IPython.core.interactiveshell import InteractiveShell
+
 
 def find_notebook(fullname, path=None):
     """find a notebook, given its fully qualified name and an optional path
@@ -22,30 +26,24 @@ def find_notebook(fullname, path=None):
         if os.path.isfile(nb_path):
             return nb_path
 
+
 class NotebookLoader(object):
     """Module Loader for Jupyter Notebooks"""
     def __init__(self, path=None):
         self.shell = InteractiveShell.instance()
         self.path = path
 
-    def load_module(self, fullname):
+    def create_module(self, spec):
         """import a notebook as a module"""
-        path = find_notebook(fullname, self.path)
+        path = find_notebook(spec.name, self.path)
+        print("importing Jupyter notebook from %s" % path)
+        mod = ModuleSpec(name=spec.name, loader=self, origin=path)
+        return mod
 
-        print ("importing Jupyter notebook from %s" % path)
-
+    def exec_module(self, mod):
         # load the notebook object
-        with io.open(path, 'r', encoding='utf-8') as f:
+        with io.open(mod.origin, 'r', encoding='utf-8') as f:
             nb = read(f, 4)
-
-
-        # create the module and add it to sys.modules if name in sys.modules:
-        #    return sys.modules[name]
-        mod = types.ModuleType(fullname)
-        mod.__file__ = path
-        mod.__loader__ = self
-        mod.__dict__['get_ipython'] = get_ipython
-        sys.modules[fullname] = mod
 
         # extra work to ensure that magics that would affect the user_ns
         # actually affect the notebook module's ns
@@ -53,15 +51,14 @@ class NotebookLoader(object):
         self.shell.user_ns = mod.__dict__
 
         try:
-          for cell in nb.cells:
-            if cell.cell_type == 'code':
-                # transform the input to executable Python
-                code = self.shell.input_transformer_manager.transform_cell(cell.source)
-                # run the code in themodule
-                exec(code, mod.__dict__)
+            for cell in nb.cells:
+                if cell.cell_type == 'code':
+                    # transform the input to executable Python
+                    code = self.shell.input_transformer_manager.transform_cell(cell.source)
+                    # run the code in themodule
+                    exec(code, mod.__dict__)
         finally:
             self.shell.user_ns = save_user_ns
-        return mod
 
 
 class NotebookFinder(object):
@@ -69,19 +66,12 @@ class NotebookFinder(object):
     def __init__(self):
         self.loaders = {}
 
-    def find_module(self, fullname, path=None):
+    def find_spec(self, fullname, path=None, target=None):
         nb_path = find_notebook(fullname, path)
         if not nb_path:
             return
-
-        key = path
-        if path:
-            # lists aren't hashable
-            key = os.path.sep.join(path)
-
-        if key not in self.loaders:
-            self.loaders[key] = NotebookLoader(path)
-        return self.loaders[key]
+        return importlib.util.spec_from_loader(fullname, NotebookLoader(path), is_package=False)
 
 
 sys.meta_path.append(NotebookFinder())
+


### PR DESCRIPTION
Adaptation for Python3.12. Deleting find_module() method, deprecated in Python3.10, and using the find_spec(). Replacing the method load_module() with two methods: create_module() and exec_module() with the application of ModuleSpec.